### PR TITLE
[TT-13363] Enable streaming for Tyk Pro Deployment.

### DIFF
--- a/pro/tyk-analytics.conf
+++ b/pro/tyk-analytics.conf
@@ -5,6 +5,9 @@
         "Port": "8080",
         "Secret": "352d20ee67be67f6340b4c0605b044b7"
     },
+    "streaming": {
+        "enabled": true
+    },
     "enable_ownership": true,
     "mongo_use_ssl": false,
     "mongo_ssl_insecure_skip_verify": false,

--- a/pro/tyk.conf
+++ b/pro/tyk.conf
@@ -13,6 +13,9 @@
         "policy_record_name": "tyk_policies",
         "allow_explicit_policy_id": true
     },
+    "streaming": {
+        "enabled": true
+    },
     "use_db_app_configs": true,
     "db_app_conf_options": {
         "connection_string": "http://tyk-analytics:3000",


### PR DESCRIPTION
PR for https://tyktech.atlassian.net/browse/TT-13363

We need to enable streaming in Tyk-Pro deployment to fix this problem: https://github.com/TykTechnologies/tyk-analytics/actions/runs/11442388028/job/31832885152?pr=4181#step:9:698

The integration test gets 404 to WebSocket handshake request because Tyk Streams are not enabled in Tyk Pro deployment setup. 

See also: https://github.com/TykTechnologies/tyk-pro/pull/22