### PR TITLE
[TT-15811] k6 and upstream pods for resilience tests

### DIFF
--- a/k8s/tyk-stack-ingress/Taskfile.yaml
+++ b/k8s/tyk-stack-ingress/Taskfile.yaml
@@ -96,7 +96,60 @@ tasks:
         echo "  - MongoDB: localhost:8480"
         echo "To stop port-forwarding, run: task -d k8s/tyk-stack-ingress stop-port-forward"
 
+  run-k6-test-with-dashboard:
+    desc: Runs k6 test with dashboard enabled
+    vars:
+      TARGET_NAMESPACE: '{{.TARGET_NAMESPACE}}'
+      API_NAME: '{{.API_NAME}}'
+      DURATION: '{{.DURATION}}'
+    cmds:
+      - |
+        # Set environment variables and run k6 with dashboard output
+        echo "Starting k6 test with dashboard..."
+        kubectl exec -n tools deploy/k6-runner -c k6 -- env NAMESPACE={{.TARGET_NAMESPACE}} API_NAME={{.API_NAME}} TEST_DURATION={{.DURATION}} k6 run --out 'dashboard=host=0.0.0.0&port=5665&period=2s' /scripts/test-script.js &
+        
+        # Wait for the dashboard to be ready
+        echo "Waiting for dashboard to be ready..."
+        sleep 3
+        
+        # Start port-forwarding automatically
+        echo "Starting port-forward for k6 dashboard..."
+        echo "Access the dashboard at http://localhost:5665"
+        echo "Press Ctrl+C to stop the port-forward when done."
+        kubectl port-forward -n tools svc/k6-dashboard 5665:5665
+
+  run-k6-test:
+    desc: Runs k6 test with custom parameters for target namespace, API name, duration, and optional dashboard
+    cmds:
+      - |
+        # Get parameters with defaults
+        TARGET_NAMESPACE={{.target_namespace | default "tyk-dp-1"}}
+        API_NAME={{.api_name | default "test"}}
+        DURATION={{.duration | default "30s"}}
+        DASHBOARD={{.dashboard | default "false"}}
+        
+        echo "Starting k6 test with the following parameters:"
+        echo "Target Namespace: $TARGET_NAMESPACE"
+        echo "API Name: $API_NAME"
+        echo "Test Duration: $DURATION"
+        echo "Dashboard: $DASHBOARD"
+        
+        # Kill any existing k6 dashboard process first
+        echo "Killing any existing k6 dashboard process..."
+        kubectl exec -n tools deploy/k6-runner -c k6 -- pkill -f "k6.*dashboard" || echo "No existing k6 dashboard process found"
+        sleep 1
+        
+        if [ "$DASHBOARD" = "true" ]; then
+          # Run with dashboard using the dedicated task
+          task -d k8s/tyk-stack-ingress run-k6-with-dashboard TARGET_NAMESPACE=$TARGET_NAMESPACE API_NAME=$API_NAME DURATION=$DURATION
+        else
+          # Run k6 without dashboard
+          echo "Starting k6 test without dashboard..."
+          kubectl exec -n tools deploy/k6-runner -c k6 -- env NAMESPACE=$TARGET_NAMESPACE API_NAME=$API_NAME TEST_DURATION=$DURATION k6 run /scripts/test-script.js
+          echo "Test completed."
+        fi
+
   clean:
     desc: Deletes all Tyk namespaces and resources from the Kubernetes cluster
     cmds:
-      - kubectl delete namespace tyk tyk-dp-1 tyk-dp-2
+      - kubectl delete namespace tyk tyk-dp-1 tyk-dp-2 tools

--- a/k8s/tyk-stack-ingress/flask-upstream.yaml
+++ b/k8s/tyk-stack-ingress/flask-upstream.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flask-upstream
+  namespace: tools
+  labels:
+    app: flask-upstream
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flask-upstream
+  template:
+    metadata:
+      labels:
+        app: flask-upstream
+    spec:
+      containers:
+      - name: flask-app
+        image: python:3.9-slim
+        ports:
+        - containerPort: 5000
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          pip install flask
+          cat > app.py << 'EOF'
+          from flask import Flask, jsonify
+          
+          app = Flask(__name__)
+          
+          @app.route('/upstream', methods=['GET'])
+          def upstream():
+              return jsonify({"message": "Hello from upstream service!"})
+          
+          if __name__ == '__main__':
+              app.run(host='0.0.0.0', port=5000)
+          EOF
+          python app.py
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flask-upstream
+  namespace: tools
+spec:
+  selector:
+    app: flask-upstream
+  ports:
+  - port: 5000
+    targetPort: 5000
+  type: ClusterIP

--- a/k8s/tyk-stack-ingress/k6.yaml
+++ b/k8s/tyk-stack-ingress/k6.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k6-test-script
+  namespace: tools
+data:
+  test-script.js: |
+    import http from 'k6/http';
+    import { sleep, check } from 'k6';
+    
+    // Get environment variables with defaults
+    const API_NAME = __ENV.API_NAME || 'test';
+    const TEST_DURATION = __ENV.TEST_DURATION || '30s';
+    const TARGET_NAMESPACE = __ENV.TARGET_NAMESPACE || 'tyk-dp-1';
+    
+    export const options = {
+      vus: 10,
+      duration: TEST_DURATION,
+      thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<500']
+      },
+      // Add summary export for better output
+      summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)']
+    };
+
+    export default function() {
+      const res = http.get(`http://gateway-svc-tyk-data-plane-tyk-gateway.${TARGET_NAMESPACE}.svc.cluster.local:8080/${API_NAME}/upstream`);
+      check(res, {
+        'status is 200': (r) => r.status === 200,
+      });
+      sleep(1);
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k6-runner
+  namespace: tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k6-runner
+  template:
+    metadata:
+      labels:
+        app: k6-runner
+    spec:
+      volumes:
+        - name: k6-test-script
+          configMap:
+            name: k6-test-script
+      containers:
+      - name: k6
+        image: ghcr.io/grafana/xk6-dashboard:0.6.1
+        command: ["sleep", "infinity"]
+        env:
+        - name: API_NAME
+          value: "test"
+        - name: TEST_DURATION
+          value: "30s"
+        - name: TARGET_NAMESPACE
+          value: "tyk-dp-1"
+        volumeMounts:
+          - { name: k6-test-script, mountPath: /scripts }
+        ports:
+          - containerPort: 5665
+            name: dashboard
+        resources:
+          limits: { memory: "512Mi", cpu: "500m" }
+          requests: { memory: "256Mi", cpu: "250m" }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k6-dashboard
+  namespace: tools
+spec:
+  selector:
+    app: k6-runner
+  ports:
+  - port: 5665
+    targetPort: dashboard
+  type: ClusterIP

--- a/k8s/tyk-stack-ingress/readme.md
+++ b/k8s/tyk-stack-ingress/readme.md
@@ -60,6 +60,9 @@ You can also enable Toxiproxy for testing network issues:
   - Tyk Gateway (2 replicas)
   - Redis
   - Ingress
+- **Tools (tools namespace)**:
+  - Flask Upstream - A simple Flask application that serves as an upstream service for API testing
+  - k6 Runner - A load testing tool for sending traffic to the gateways
 
 #### Ingress Configuration
 The script automatically configures:
@@ -145,6 +148,8 @@ This project includes a Taskfile.yaml that provides convenient commands for mana
 | `start-port-forward` | Port-forwards all Tyk services and saves logs to a file | `task -d k8s/tyk-stack-ingress start-port-forward` |
 | `stop-port-forward` | Stops all kubectl port-forward processes | `task -d k8s/tyk-stack-ingress stop-port-forward` |
 | `start-toxiproxy-forward` | Port-forwards the Toxiproxy API and all proxies to localhost | `task -d k8s/tyk-stack-ingress start-toxiproxy-forward` |
+| `run-k6-test` | Runs k6 test with custom parameters | `task -d k8s/tyk-stack-ingress run-k6-test target_namespace=tyk-dp-1 api_name=test duration=30s dashboard=false` |
+| `run-k6-with-dashboard` | Runs k6 test with dashboard enabled | `task -d k8s/tyk-stack-ingress run-k6-with-dashboard TARGET_NAMESPACE=tyk-dp-1 API_NAME=test DURATION=30s` |
 | `clean` | Deletes all Tyk namespaces and resources from the Kubernetes cluster | `task -d k8s/tyk-stack-ingress clean` |
 
 ### Port Forwarding with Task
@@ -178,6 +183,50 @@ task -d k8s/tyk-stack-ingress start-toxiproxy-forward
 ```
 
 This makes the Toxiproxy API available at http://localhost:8474, where you can control network conditions for testing.
+
+## Load Testing with k6
+
+The deployment includes a k6 load testing pod in the `tools` namespace that can be used to send traffic to any of the data plane gateways. This is useful for testing API performance, stability, and behavior under load.
+
+### Flask Upstream Service
+
+The deployment includes a simple Flask application in the `tools` namespace that serves as an upstream service for API testing. This service exposes an endpoint at `/upstream` that returns a JSON response. When creating APIs in the Tyk Dashboard, you can use this service as the upstream target with the URL:
+
+```
+http://flask-upstream.tools.svc:5000
+```
+
+### Running Load Tests
+
+You can run load tests using the following task commands:
+
+#### Basic Load Test
+
+```bash
+task -d k8s/tyk-stack-ingress run-k6-test
+```
+
+This runs a basic load test against the default data plane gateway.
+
+#### Custom Load Test
+
+```bash
+task -d k8s/tyk-stack-ingress run-k6-test-custom target_namespace=tyk-dp-1 api_name=test duration=30s
+```
+
+Parameters:
+- `target_namespace`: The namespace of the gateway to test (default: tyk-dp-1)
+- `api_name`: The name of the API to test (default: test)
+- `duration`: How long to run the test (default: 30s)
+- `dashboard`: Whether to enable the k6 dashboard (default: false)
+
+#### Load Test with Dashboard
+
+```bash
+task -d k8s/tyk-stack-ingress run-k6-test-custom target_namespace=tyk-dp-1 api_name=test duration=30s dashboard=true
+```
+
+This runs a load test with the k6 dashboard enabled, which provides real-time metrics visualization. The dashboard will be available at http://localhost:5665.
 
 ## Executing tests
 

--- a/k8s/tyk-stack-ingress/run-tyk-cp-dp.sh
+++ b/k8s/tyk-stack-ingress/run-tyk-cp-dp.sh
@@ -188,6 +188,27 @@ for i in $(seq 1 $NUM_DATA_PLANES); do
     --set tyk-gateway.gateway.ingress.className="nginx" --wait
 
   log "----- Successfully installed tyk-data-plane-${i} -----"
+
 done
+
+log "----- Creating tools namespace -----"
+kubectl create namespace tools || true
+
+log "----- Installing Flask upstream app in tools namespace -----"
+kubectl apply -f flask-upstream.yaml
+if [ $? -ne 0 ]; then
+  error "Failed to install Flask upstream app in tools namespace"
+  exit 1
+fi
+log "Flask upstream app deployed successfully at flask-upstream.tools.svc:5000/upstream"
+
+log "----- Installing k6 load testing resources in tools namespace -----"
+kubectl apply -f k6.yaml
+if [ $? -ne 0 ]; then
+  error "Failed to install k6 load testing resources"
+  exit 1
+fi
+log "----- Successfully installed k6 load testing resources -----"
+log "To run a test, use the run-k6-test-custom task with parameters"
 
 log "--> $0 Done"


### PR DESCRIPTION
In resilience tests we need a stable upstream service (online httpbin often returns 502) and a tool to send continues traffic to edge gateway.
In this PR I'm adding:
- simple flask api server (as a pod in tools namespace) that could be used as upstream in API definition
- k6 pod that will send traffic to edge gateways on demand
- task commands to start traffic

